### PR TITLE
Fix 'wasted' click bug on Practice view resolving #16

### DIFF
--- a/client/src/components/Card.jsx
+++ b/client/src/components/Card.jsx
@@ -9,6 +9,7 @@ const Card = (props) => {
     // Change in set resets cards
     useEffect(() => {
         setIsFlipped(false)
+        
     }, [sets])
     // Change in cardShowing unflips all but the match to cardKey
     useEffect(() => {

--- a/client/src/components/CardList.jsx
+++ b/client/src/components/CardList.jsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import Card from './Card';
 
-const CardList = ({card, sets}) => {
-    const [cardShowing, setCardShowing] = useState("");
+const CardList = ({card, sets, cardShowing, setCardShowing}) => {
+    
     const getCardShowing = (cardKey) => {
         setCardShowing(cardKey)
     }

--- a/client/src/views/Practice.js
+++ b/client/src/views/Practice.js
@@ -11,6 +11,7 @@ const Practice = (props) => {
     const [card, setCard] = useState([]);
     const [loaded, setLoaded] = useState(false);
     const [sets, setSets] = useState(0);
+    const [cardShowing, setCardShowing] = useState("");
 
     useEffect(() => {
         axios.get(BASE_URL + '/api/random')
@@ -30,7 +31,8 @@ const Practice = (props) => {
     // could add possiblity to call more than 3 cards
     //for now hard coded to another "set" of 3
     const newSet = (number)=> {
-        setSets(sets+1)
+        setSets(sets+1);
+        setCardShowing("");
     }
 
     return (
@@ -41,7 +43,13 @@ const Practice = (props) => {
             <p>Click on a flashcard to see the other side!</p>
             <hr /><br />
             {loaded ?
-                <CardList card={card} removeFromDom={removeFromDom} sets={sets} /> //true
+                <CardList //true
+                    card={card} 
+                    removeFromDom={removeFromDom} 
+                    sets={sets} 
+                    cardShowing={cardShowing}
+                    setCardShowing={setCardShowing}
+                />
                 :
                 <div className="d-flex align-items-center justify-content-center">
                     <strong>I know they're here somewhere...</strong>


### PR DESCRIPTION
##What
Migrate `const [cardShowing, setCardShowing] = useState("");` from CardList.jsx component to parent view Practice.js

##Why
The Practice view lacked access to setCardShowing. When a new set would load after clicking the 'Another set?' button, the cardShowing state variable held onto the id of the last unflipped card, causing the the first click on the card occupying the same index in the array to remain unflipped. This only stopped the first click of the same card position to do nothing; A second click would resume the expected behavior of the cardFlip logic.

##How
By moving the cardShowing and setCardShowing state construction to it's previous parent view and passing it back down through props to the CardList component, Practice could access `setCardShowing` in the `newSet` function that the 'Another set?' button invokes. Resetting the cardShowing back to "" inside the newSet function causes the card flip logic to perform as expected.

Please let me know if you have any questions or issues with this PR that I can accommodate.